### PR TITLE
add photos with wikimedia

### DIFF
--- a/taginfo.json
+++ b/taginfo.json
@@ -1,0 +1,61 @@
+{
+    "data_format": 1,
+    "data_url": "https://www.defikarte.ch/taginfo.json",
+    "data_updated": "20240927T200000Z",
+    "project": {         
+        "name": "Defikarte.ch",
+        "description": "A map to show the next defibrillator with OpenStreetMap data",   
+        "project_url": "https://www.defikarte.ch",
+        "icon_url": "https://defikarte.ch/assets/defikarte-logo-C2rpPPds.svg",
+        "contact_name": "Christian Nüssli",
+        "contact_email": "christian@openbrackets.ch"
+    },
+    "tags": [
+        {
+            "key": "emergency",
+            "value": "defibrillator",        
+            "description": "To mark a defi on the map and work woth it."
+        },
+        {
+            "key": "defribillator:location",
+            "description": "To describe the location of a defibrillator in words"
+        },
+        {
+            "key": "opening_hours",
+            "description": "To map the opening_hours of a defibrillator"
+        },
+        {
+            "key": "indoor",
+            "description": "To describe if a defi is in or outside"
+        },
+        {
+            "key": "access",
+            "description": "To describe the accessability of a defi"
+        },
+        {
+            "key": "emergency:phone",
+            "value": "144",
+            "description": "the national emergency number in switzerland"
+        },
+        {
+            "key": "level",
+            "description": "level of a defi"
+        },
+        {
+            "key": "description",
+            "description": "To describe the situation around the defi or for more information"
+        },
+        {
+            "key": "operator",
+            "description": "Describes the operator of the defi"
+        },
+                {
+            "key": "email",
+            "description": "the email address, either the operator or the defi itself"
+        },
+        {
+            "key": "phone",
+            "description": "the phone number, either the operator or the defi itself"
+        }
+    ]
+}


### PR DESCRIPTION
feat: show Wikimedia Commons photo in detail view

Displays a photo in the defi detail panel when the OSM node
has a wikimedia_commons=* or image=* tag set.

- New component DefiPhoto fetches thumbnail via Commons MediaWiki API
- Renders photo + attribution link in FeaturePropsList
- No backend changes, no own database, no new dependencies
- Silent fallback if tag is missing or API unavailable

To add a photo to a defi:
1. Upload photo to https://commons.wikimedia.org
2. Set tag wikimedia_commons=File:YourPhoto.jpg on the OSM node

Solves: https://github.com/OpenBracketsCH/defikarte.ch/issues/81